### PR TITLE
Switch to common-android14-6.1-lts manifest & Update documentation for kleaf

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 2. Initialize repo:
 
 ```
-repo init -u https://android.googlesource.com/kernel/manifest -b common-android13-5.15-lts
+repo init -u https://android.googlesource.com/kernel/manifest -b common-android14-6.1-lts
 curl -o .repo/local_manifests/manifest_brcm_rpi.xml -L https://raw.githubusercontent.com/raspberry-vanilla/android_kernel_manifest/android-14.0/manifest_brcm_rpi.xml --create-dirs
 ```
 
@@ -19,14 +19,14 @@ repo sync
 
 Raspberry Pi 4:
 ```
-BUILD_CONFIG=common/build.config.rpi4 build/build.sh
+tools/bazel build --config=fast //common:rpi4
 ```
 
 Raspberry Pi 5:
 ```
-BUILD_CONFIG=common/build.config.rpi5 build/build.sh
+tools/bazel build --config=fast //common:rpi5
 ```
 
-Compiled kernel Image, dtbs, and overlays can be found in `out/common/arch/arm64/boot` directory.
+Compiled kernel Image, dtbs, and overlays can be found in `bazel-bin/common/rpi4/arch/arm64/boot` or `bazel-bin/common/rpi5/arch/arm64/boot` directory.
 
 Replace existing files in `device/brcm/rpi4-kernel` or `device/brcm/rpi5-kernel` directory of the Android source tree to include them in Android 14 build. You can also replace existing files in the boot partition of Raspberry Pi 4 or Raspberry Pi 5 Android 14 image.


### PR DESCRIPTION
I hate Bazel

Both RPi4 & RPi5 are buildable. However I can only test RPi5 because that's the only board I have